### PR TITLE
Rename project to MiHealth AmapFix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# MiHealth-Gaode_Fix(LSPosed module)
+# MiHealth AmapFix (LSPosed module)
 **修复点**：小米运动健康 (Mi Fitness) 3.44.0 引入 `NotificationFilterHelper.isMipmapNotification(StatusBarNotification)`，
 对 `com.autonavi.minimap`（高德地图）导航常驻焦点通知 (id = `0x4d4`) 做了特判，导致实时导航信息不再被转发到手表/手环。
 本模块在运行时 Hook 该方法，**强制返回 `false`**，从而不再拦截这条焦点通知。
 ### 注：高德地图的导航焦点通知理论只在 HyperOS 2.0 以上版本显示，且需高德地图的版本支持，请确保你在系统通知栏能在步行/骑行导航时看到导航的焦点通知信息后再使用本模块解锁限制。
 
-- 兼容 **LSPosed 新 API (api:100)**：现代入口 `io.github.amapnotifyfix.ModernEntry`
-- 兼容 **旧 XposedBridge API**：传统入口 `io.github.amapnotifyfix.LegacyInit`
+- 兼容 **LSPosed 新 API (api:100)**：现代入口 `io.github.mihealthamapfix.ModernEntry`
+- 兼容 **旧 XposedBridge API**：传统入口 `io.github.mihealthamapfix.LegacyInit`
 - 推荐在 LSPosed 中**只勾选**「小米运动健康」应用的作用域
 
 ## 构建
@@ -19,7 +19,7 @@
 ```bash
 # 先安装 JDK 21 和 Gradle（或者用 Android Studio 打开）
 git clone YOUR_REPO_URL
-cd MiFitnessAmapNavFix
+cd MiHealthAmapFix
 # JDK 17 可能可用但不保证
 
 # 准备 Gradle Wrapper（首次构建）

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,11 @@ kotlin {
 }
 
 android {
-    namespace "io.github.mihealthgaodefix"
+    namespace "io.github.mihealthamapfix"
     compileSdk 34
 
     defaultConfig {
-        applicationId "io.github.mihealthgaodefix"
+        applicationId "io.github.mihealthamapfix"
         minSdk 24
         targetSdk 34
         versionCode 2

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,7 +1,7 @@
 # 让 LSPosed 能通过类名加载到入口与 Hooker（名字不能被混淆/删除）
--keep class io.github.amapnotifyfix.ModernEntry { *; }
--keep class io.github.amapnotifyfix.ModernEntry$IsMipmapHooker { *; }
--keep class io.github.amapnotifyfix.LegacyInit { *; }
+-keep class io.github.mihealthamapfix.ModernEntry { *; }
+-keep class io.github.mihealthamapfix.ModernEntry$IsMipmapHooker { *; }
+-keep class io.github.mihealthamapfix.LegacyInit { *; }
 
 # 保留 libxposed Hooker 的静态回调方法签名（before/after）
 -keepclassmembers class * implements io.github.libxposed.api.XposedInterface$Hooker {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.mihealthgaodefix">
+    package="io.github.mihealthamapfix">
 
     <application
-        android:label="Mi Fitness Amap Nav Fix"
+        android:label="MiHealth AmapFix"
         android:description="@string/module_description"
         android:allowBackup="false"
         android:supportsRtl="true">

--- a/app/src/main/assets/xposed_init
+++ b/app/src/main/assets/xposed_init
@@ -1,1 +1,1 @@
-io.github.amapnotifyfix.LegacyInit
+io.github.mihealthamapfix.LegacyInit

--- a/app/src/main/java/io/github/mihealthamapfix/HookConstants.java
+++ b/app/src/main/java/io/github/mihealthamapfix/HookConstants.java
@@ -1,4 +1,4 @@
-package io.github.amapnotifyfix;
+package io.github.mihealthamapfix;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/app/src/main/java/io/github/mihealthamapfix/LegacyInit.java
+++ b/app/src/main/java/io/github/mihealthamapfix/LegacyInit.java
@@ -1,4 +1,4 @@
-package io.github.amapnotifyfix;
+package io.github.mihealthamapfix;
 
 import android.service.notification.StatusBarNotification;
 
@@ -9,9 +9,9 @@ import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
-import static io.github.amapnotifyfix.HookConstants.AMAP_NAV_ID;
-import static io.github.amapnotifyfix.HookConstants.AMAP_PACKAGE;
-import static io.github.amapnotifyfix.HookConstants.TARGET_PACKAGES;
+import static io.github.mihealthamapfix.HookConstants.AMAP_NAV_ID;
+import static io.github.mihealthamapfix.HookConstants.AMAP_PACKAGE;
+import static io.github.mihealthamapfix.HookConstants.TARGET_PACKAGES;
 
 /**
  * Legacy Xposed entry (works in LSPosed too).

--- a/app/src/main/java/io/github/mihealthamapfix/ModernEntry.java
+++ b/app/src/main/java/io/github/mihealthamapfix/ModernEntry.java
@@ -1,4 +1,4 @@
-package io.github.amapnotifyfix;
+package io.github.mihealthamapfix;
 
 import android.service.notification.StatusBarNotification;
 
@@ -9,9 +9,9 @@ import io.github.libxposed.api.XposedInterface;
 import io.github.libxposed.api.XposedModule;
 import io.github.libxposed.api.XposedModuleInterface;
 
-import static io.github.amapnotifyfix.HookConstants.AMAP_NAV_ID;
-import static io.github.amapnotifyfix.HookConstants.AMAP_PACKAGE;
-import static io.github.amapnotifyfix.HookConstants.TARGET_PACKAGES;
+import static io.github.mihealthamapfix.HookConstants.AMAP_NAV_ID;
+import static io.github.mihealthamapfix.HookConstants.AMAP_PACKAGE;
+import static io.github.mihealthamapfix.HookConstants.TARGET_PACKAGES;
 
 /**
  * Modern LSPosed (libxposed API 100) entry.
@@ -37,9 +37,9 @@ public class ModernEntry extends XposedModule {
             Class<?> helper = cl.loadClass("com.xiaomi.fitness.notify.util.NotificationFilterHelper");
             Method m = helper.getDeclaredMethod("isMipmapNotification", StatusBarNotification.class);
             hook(m, IsMipmapHooker.class);
-            log("MiFitnessAmapNavFix: hooked isMipmapNotification in " + pkg);
+            log("MiHealthAmapFix: hooked isMipmapNotification in " + pkg);
         } catch (Throwable t) {
-            log("MiFitnessAmapNavFix: method not found; maybe old version. " + t);
+            log("MiHealthAmapFix: method not found; maybe old version. " + t);
         }
     }
 

--- a/app/src/main/resources/META-INF/xposed/java_init.list
+++ b/app/src/main/resources/META-INF/xposed/java_init.list
@@ -1,1 +1,1 @@
-io.github.amapnotifyfix.ModernEntry
+io.github.mihealthamapfix.ModernEntry

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,5 +16,5 @@ dependencyResolutionManagement {
         maven { url = uri("https://api.xposed.info/") }
     }
 }
-rootProject.name = "MiFitnessAmapNavFix"
+rootProject.name = "MiHealthAmapFix"
 include(":app")


### PR DESCRIPTION
## Summary
- rename LSPosed module to **MiHealth AmapFix**
- update package and module identifiers to `io.github.mihealthamapfix`
- adjust manifest, build scripts, and Xposed config to match new name

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac6164cb9883238f9c7752084612ca